### PR TITLE
Misleading label + windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The install.sh script includes:
     sudo pip install fiona
     sudo pip install Django==1.8
 
+Windows users might find the file requirements_win64.pip helpful.
+Follow the commented instructions inside it and use this to install packages:
+    pip install -r requirements_win64.pip
+
 ## Notes
 
 The Django app use shapely and Fiona, to learn more about these see:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The install.sh script includes:
 
 Windows users might find the file requirements_win64.pip helpful.
 Follow the commented instructions inside it and use this to install packages:
+
     pip install -r requirements_win64.pip
 
 ## Notes

--- a/converter/main/templates/index.html
+++ b/converter/main/templates/index.html
@@ -64,7 +64,7 @@
 							</select>
 							</div>
 							<div id="lng_field_box">
-							<label for="lng_field">Select Lat Field</label>
+							<label for="lng_field">Select Lon Field</label>
 							<select class="form-control" name="lng_field" id="lng_field">
 							<option value="none">-- Select Field --</option>
 							{% for s in schema %}

--- a/requirements_win64.pip
+++ b/requirements_win64.pip
@@ -1,0 +1,10 @@
+# Download the four commented out wheel files from here (you might find only newer versions and hope it works): https://www.lfd.uci.edu/~gohlke/pythonlibs/
+# C:\Wheels\numpy-1.14.1+mkl-cp27-cp27m-win_amd64.whl
+# C:\Wheels\GDAL-2.2.3-cp27-cp27m-win_amd64.whl
+# C:\Wheels\Shapely-1.6.4.post1-cp27-cp27m-win_amd64.whl
+# C:\Wheels\Fiona-1.7.11.post1-cp27-cp27m-win_amd64.whl
+six
+cligj
+argparse
+ordereddict
+Django==1.8


### PR DESCRIPTION
The "Select Lat Field" label was for both: latitude and longitude.
Also, I spend 3 hours trying to get it working on windows, so I included some info to help other windows users out.